### PR TITLE
Strip PyPI `mkl` runtime dep added in 2.7.1 (fixes downstream `pip check`)

### DIFF
--- a/recipe/0001-drop-pypi-mkl-runtime-dep.patch
+++ b/recipe/0001-drop-pypi-mkl-runtime-dep.patch
@@ -1,0 +1,23 @@
+From: Ben Mares <services-mkl-service-feedstock@tensorial.com>
+Subject: [PATCH] Drop PyPI mkl runtime dependency for conda-forge build
+
+Upstream commit c790ca346e ("add mkl-devel as build dependency and mkl
+as runtime dependency") added `dependencies = ["mkl"]` to pyproject.toml.
+That declares a runtime dependency on the PyPI `mkl` wheel, which is
+satisfied on PyPI but not on conda-forge: the conda-forge `mkl` package
+provides the libraries via conda metadata only and ships no pip-visible
+.dist-info. The conda-level `run: mkl` requirement already pulls in the
+runtime, so we just need to remove the redeclaration to keep `pip check`
+happy in downstream environments.
+
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -56,7 +56,7 @@ classifiers = [
+   "Operating System :: POSIX",
+   "Operating System :: Unix"
+ ]
+-dependencies = ["mkl"]
++dependencies = []
+ description = "Python hooks for Intel® oneAPI Math Kernel Library (oneMKL) runtime control settings"
+ dynamic = ["version"]
+ keywords = ["MKL"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,16 @@ package:
 source:
   url: https://github.com/IntelPython/mkl-service/archive/{{ version }}.tar.gz
   sha256: a1d7f972dd98f29926dab8388c0e99229f0f6f5ebfe87f2848639fbd6781a573
+  patches:
+    # Drop `dependencies = ["mkl"]` from pyproject.toml. The PyPI `mkl` wheel
+    # that satisfies it is not packaged on conda-forge, and the conda-level
+    # `run: mkl` already pulls in the runtime — so without the patch, every
+    # downstream `pip check` reports `mkl-service requires mkl, which is not
+    # installed`.
+    - 0001-drop-pypi-mkl-runtime-dep.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx and arm64]
   ignore_run_exports:
     - blas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,16 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest <8    # [python_impl == "pypy"]
     - pytest       # [not (python_impl == "pypy")]
   imports:
     - mkl
   commands:
+      # Catch future regressions where upstream wheel metadata declares a
+      # PyPI dependency that conda-forge does not provide (see the
+      # 0001-drop-pypi-mkl-runtime-dep.patch source patch).
+    - pip check
       # calling get_version upsets test_cbwr_*, bug filed, so exclude, but run separately
     - pytest -vv --pyargs mkl -k "not test_get_version"
     - pytest -vv --pyargs mkl -k "test_get_version"


### PR DESCRIPTION
## Summary

Upstream commit [IntelPython/mkl-service@c790ca3](https://github.com/IntelPython/mkl-service/commit/c790ca346e) ("*add mkl-devel as build dependency and mkl as runtime dependency*"), first shipped in **2.7.1**, changed `pyproject.toml`:

```diff
-dependencies = []
+dependencies = ["mkl"]
```

That declares a runtime dependency on the PyPI `mkl` wheel. On conda-forge there is no pip-visible `mkl` distribution — the `mkl` conda package ships only conda metadata, no `.dist-info` — so every environment that includes `mkl-service 2.7.1` now fails `pip check` with:

```
mkl-service 2.7.1 requires mkl, which is not installed.
```

Because the recipe didn't run `pip check` itself, this slipped through and is now surfacing in downstream feedstocks. First report I'm aware of: pytensor-suite, where a test step (`pip check` after the conda solve) breaks the build.

This PR:

1. Adds `recipe/0001-drop-pypi-mkl-runtime-dep.patch` to revert that one line back to `dependencies = []`. The conda-level `run: mkl` already pulls in the runtime, so the metadata redeclaration is purely harmful in the conda-forge build.
2. Bumps `build.number` from 1 → 2 so a new build is produced for the existing 2.7.1 source.
3. Adds `pip check` to the recipe's `test.commands` (and `pip` to `test.requires`) so a regression of this exact shape gets caught in-recipe in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)